### PR TITLE
Allow VACE video processor to honor requested frame count

### DIFF
--- a/wan/vace.py
+++ b/wan/vace.py
@@ -295,7 +295,9 @@ class WanVace(WanT2V):
             if sub_src_mask is not None and sub_src_video is not None:
                 src_video[i], src_mask[
                     i], _, _, _ = self.vid_proc.load_video_pair(
-                        sub_src_video, sub_src_mask)
+                        sub_src_video,
+                        sub_src_mask,
+                        num_frames=num_frames)
                 src_video[i] = src_video[i].to(device)
                 src_mask[i] = src_mask[i].to(device)
                 src_mask[i] = torch.clamp(
@@ -308,7 +310,8 @@ class WanVace(WanT2V):
                 src_mask[i] = torch.ones_like(src_video[i], device=device)
                 image_sizes.append(image_size)
             else:
-                src_video[i], _, _, _ = self.vid_proc.load_video(sub_src_video)
+                src_video[i], _, _, _ = self.vid_proc.load_video(
+                    sub_src_video, num_frames=num_frames)
                 src_video[i] = src_video[i].to(device)
                 src_mask[i] = torch.ones_like(src_video[i], device=device)
                 image_sizes.append(src_video[i].shape[2:])


### PR DESCRIPTION
## Summary
- forward the requested frame count from WanVace.prepare_source into the video processor loaders
- extend VaceVideoProcessor APIs to accept an explicit frame count and propagate it through frame selection
- adjust frame selection logic to respect long video requests when a frame count is supplied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e06f7de39c832b83313e10ebdf7a79